### PR TITLE
Create afacademy.txt

### DIFF
--- a/lib/domains/edu/af/afacademy.txt
+++ b/lib/domains/edu/af/afacademy.txt
@@ -1,0 +1,1 @@
+United States Air Force Academy


### PR DESCRIPTION
https://www.usafa.edu/

Email accounts are now listed under "@afacademy.af.edu", not "@usafa.edu"